### PR TITLE
Improved sourcing

### DIFF
--- a/plugin/autosource.vim
+++ b/plugin/autosource.vim
@@ -95,7 +95,7 @@ function! s:Source(dir)
                     continue
                 endif
 
-                if rc =~? "\M.lua$" " case insensitive, nomagic
+                if rc =~? '\M.lua$' " case insensitive, nomagic
                     if has('lua')
                         exec printf('luafile %s', rc)
                     endif

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ To prevent arbitrary code execution attacks, AutoSource will prompt you to appro
 This plugin does not yet have tests and so this feature can not be guaranteed.
 
 ## Prerequisistes
-AutoSource depends `shasum` being installed on your system. MacOS must also have `uuid` and Linux must have `uuidgen`.
+AutoSource depends `shasum` being installed on your system.
 
 ## Lua files
 AutoSource will also look for `.vimrc.lua` files and source them with `:luafile`.


### PR DESCRIPTION
* While loop instead of recursion
* Moved file candidates to s:fnames list (can be later exposed as option)
* Added :autocmd! for augroup
* Removed FileReadPre
* Removed uuid/uuidgen dependency

Forgot to mention, the logic is slightly different. Originally either `.vimrc` or `.vimrc.lua` was sourced and now it can source both at the same time. There is also a `has('lua')` check.