### PR TITLE
Remove old exit condition

### DIFF
--- a/plugin/autosource.vim
+++ b/plugin/autosource.vim
@@ -163,10 +163,6 @@ endfunction
 
 " Source all `.vimrc` files in your pwd and parents up to your home dir
 function! AutoSource(dir)
-    if a:dir !~ $HOME
-        return
-    endif
-
     let i = 0
     let crumbs = split(a:dir, '/')
     while i < len(crumbs)


### PR DESCRIPTION
Following the conversation in #22 I don't see how is this needed. And it makes the function abort if not started exactly in the user home.